### PR TITLE
Add Sign-up Components

### DIFF
--- a/src/components/SignUpComponents/ProjectSignUpForm.js
+++ b/src/components/SignUpComponents/ProjectSignUpForm.js
@@ -1,0 +1,166 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+import { updateProject } from '../../actions/projects'
+import { roles as roleList } from '../../dummyData'
+
+import { FormContainer, FormGroup } from '../../components/SignUpComponents/SignUpStyleComponents'
+
+class ProjectSignUpForm extends Component {
+  state = {
+    signUpList: this.props.project ? 
+      this.props.project.signUpList : [],
+    roleInput: '',
+    nameInput: '',
+    hidden: true,
+    edit: false
+  }
+
+  // prePopulateForm = () => {
+  //   console.log(`prePopulateForm this.props: `, this.props)
+  //   this.setState({
+  //     roleInput: '',
+  //     nameInput: ''
+  //   },
+  //     () => console.log(`prePopulateForm state: `, this.state)
+  //   )
+  // }
+
+  toggleEdit() {
+    this.setState(prevState => (
+      { edit: !prevState.edit }
+    ),
+      () => {
+        // this.prePopulateForm()
+        console.log(`invoke toggleEdit`)
+      }
+    )
+  }
+
+  handleInput = e => {
+    this.setState({ [e.target.name]: e.target.value })
+  }
+
+  addData = e => {
+    console.log(`pre-addData() this.state: `, this.state)
+    e.preventDefault()
+    this.setState(prevState => {
+      if (this.state.signUpList.findIndex(slot => slot.role === this.state.roleInput) >= 0) {
+        console.log(`Invoked addData()...It matches!!`)
+        let index = prevState.signUpList.findIndex(slot => slot.role === this.state.roleInput)
+        console.log(`findIndex: `, index)
+        let updatedSignUps = [...this.state.signUpList]
+        updatedSignUps[index].name.push(this.state.nameInput)
+        console.log(`updatedSignUps: `, updatedSignUps[index])
+        return {
+          signUpList: [...updatedSignUps]
+        }
+      } else {
+        console.log(`No matches found`)
+        let newSignUp = {
+          role: this.state.roleInput,
+          name: [this.state.nameInput]
+        }
+        console.log(`newSignUp: `, newSignUp)
+
+        return {
+          signUpList: [...prevState.signUpList, newSignUp]
+        }
+      }
+    },
+      () => {
+        this.setState({
+          roleInput: '',
+          nameInput: ''
+        })
+        // Update project record
+        let updatedProject = {
+          ...this.props.project,
+          signUpList: this.state.signUpList
+        }
+        this.props.updateData(updatedProject)
+      }
+    )
+  }
+
+  handleDataUpdate = e => {
+    e.preventDefault()
+    this.setState(prevState => {
+      if (prevState.signUpList.findIndex(slot => slot.role === this.state.roleInput) >= 0) {
+        console.log(`It matches!!`)
+        let index = prevState.signUpList.findIndex(slot => slot.role === this.state.roleInput)
+        console.log(`findIndex: `, index)
+        let updatedSignUps = [...this.state.signUpList]
+        updatedSignUps[index].name = [this.state.nameInput]
+        console.log(`updatedSignUps: `, updatedSignUps[index])
+        return {
+          signUpList: [...updatedSignUps]
+        }
+      } else {
+        console.log(`No matches found`)
+        return null
+      }
+    },
+      () => {
+        this.setState({
+          roleInput: '',
+          nameInput: ''
+        })
+        // Update project record
+        let updatedProject = {
+          ...this.props.project,
+          signUpList: this.state.signUpList
+        }
+        this.props.updateData(updatedProject)
+      }
+    )
+  }
+
+  submitHandler = e => {
+    e.preventDefault()
+    if (this.props.update) {
+      this.handleDataUpdate(e)
+    } else if (this.props.delete) {
+      this.deleteData(e)
+    } else {
+      this.addData(e)
+    }
+  }
+
+  render () {
+    return (
+      <FormContainer onSubmit={this.submitHandler}>
+        <FormGroup>
+          <input
+            list="roleInput"
+            onChange={this.handleInput}
+            placeholder=" Select Role"
+            value={this.state.roleInput}
+            name="roleInput"
+          />
+          <datalist id="roleInput">
+            {roleList.map(role => (
+              <option key={role.id} value={role.name} />
+            ))}
+          </datalist>
+          <input
+            type="text"
+            onChange={this.handleInput}
+            placeholder="Sign Up"
+            value={this.state.nameInput}
+            name="nameInput"
+          />
+          <button type="submit">+</button>
+        </FormGroup>
+        
+      </FormContainer> 
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  return {
+    projects: state.projects.projects
+  }
+}
+
+export default connect(mapStateToProps,{ updateProject })(ProjectSignUpForm)

--- a/src/components/SignUpComponents/SignUp.js
+++ b/src/components/SignUpComponents/SignUp.js
@@ -1,0 +1,182 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import { updateProject } from '../../actions/projects'
+import { SignUpContainer, SignUpNameList, SignUpName, 
+  FormContainer, FormGroup } from './SignUpStyleComponents'
+import { roles as roleList } from '../../dummyData'  
+import DeleteContainer from '../../components/DesignComponents/DeleteContainer'
+
+class SignUp extends Component {
+  state = {
+    signUpList: this.props.project ? 
+      this.props.project.signUpList: [],
+    roleInput: '',
+    nameInput: '',  
+    hidden: true,
+    edit: false
+  }
+
+  // prePopulateForm = () => {
+  //   console.log(`prePopulateForm this.props: `, this.props)
+  //   this.setState({
+  //     roleInput: '',
+  //     nameInput: ''
+  //   },
+  //     () => console.log(`prePopulateForm state: `, this.state)
+  //   )
+  // }
+
+  toggleEdit() {
+    this.setState(prevState => (
+      { edit: !prevState.edit }
+    ),
+      () => {
+        // this.prePopulateForm()
+        console.log(`invoke toggleEdit`)
+      }
+    )
+  }
+
+  toggleDeleteBtn = e => {
+    e.preventDefault()
+    this.setState(prevState => ({
+      hidden: !prevState.hidden
+    }))
+  }
+
+  handleInput = e => {
+    this.setState({ [e.target.name]: e.target.value })
+  }
+
+  handleUpdate = e => {
+    e.preventDefault()
+    this.setState(prevState => {
+      if (prevState.signUpList.findIndex(slot => slot.role === this.state.roleInput) >= 0) {
+        console.log(`It matches!!`)
+        let index = prevState.signUpList.findIndex(slot => slot.role === this.state.roleInput)
+        console.log(`findIndex: `, index)
+        let updatedSignUps = [...this.state.signUpList]
+        updatedSignUps[index].name = [this.state.nameInput]
+        console.log(`updatedSignUps: `, updatedSignUps[index])
+        return {
+          signUpList: [...updatedSignUps]
+        }
+      } else {
+        console.log(`No matches found`)
+        return null
+      }
+    },
+      () => {
+        this.setState({
+          roleInput: '',
+          nameInput: ''
+        })
+        // Update project record
+        let updatedProject = {
+          ...this.props.project,
+          signUpList: this.state.signUpList
+        }
+        this.props.updateData(updatedProject)
+        this.toggleEdit()
+      }
+    )
+  }
+  
+  handleDelete = (e, index) => {
+    e.preventDefault()
+    this.setState(prevState => {
+      let splicedSignUpList = prevState.signUpList.splice(index, 1)
+      console.log(`updatedSignUpList: `, splicedSignUpList)
+      console.log(`post-splice-prevState: `, prevState.signUpList)
+      return {
+        signUpList: [...prevState.signUpList]
+      }
+    },
+      () => {
+        console.log(`SignUp handleDelete invoked state.signUpList: `, this.state.signUpList)
+        // Update project record
+        let updatedProject = {
+          ...this.props.project,
+          signUpList: this.state.signUpList
+        }
+        this.props.updateData(updatedProject)
+      }
+    )
+  }
+
+  render() {
+    const { slot, index } = this.props
+    console.log(`SignUp render state: `, this.state)
+    console.log(`SignUp render props: `, this.props)
+    return (
+      <SignUpContainer>
+        {!this.state.edit ?
+          <>
+            <div onClick={() => this.toggleEdit()}>{slot.role}:</div>
+            {slot.name.length > 1 ?
+              <SignUpNameList>
+                {slot.name.map((user, index) => (
+                  index !== slot.name.length - 1 ? `${user}, ` : user
+                ))} 
+              </SignUpNameList> :
+              <SignUpName onClick={() => this.toggleEdit()}>{slot.name}</SignUpName>
+            }
+            
+          </> :
+          <FormContainer onSubmit={this.handleUpdate}>
+            <FormGroup>
+              <input
+                list="roleInput"
+                onChange={this.handleInput}
+                placeholder=" Select Role"
+                value={this.state.roleInput}
+                name="roleInput"
+              />
+              <datalist id="roleInput">
+                {roleList.map(role => (
+                  <option key={role.id} value={role.name} />
+                ))}
+              </datalist>
+              <input
+                type="text"
+                onChange={this.handleInput}
+                placeholder="Sign Up"
+                value={this.state.nameInput}
+                name="nameInput"
+              />
+            </FormGroup>
+          </FormContainer> 
+        }
+        
+        <DeleteContainer>
+          {!this.state.edit ?
+            <i onClick={this.toggleDeleteBtn} className="fas fa-ellipsis-v"></i> :
+            <i className="far fa-edit" onClick={this.handleUpdate}></i>
+          }
+          {
+            this.state.hidden ? '' :
+              <i className="fa fa-trash"
+                aria-hidden="true"
+                onClick={(e) => this.handleDelete(e, index)}
+              >
+              </i>
+          }
+        </DeleteContainer>
+      </SignUpContainer>
+    )
+  }
+}
+
+const mapStateToProps = state => {
+  console.log(state.projects)
+  return {
+    projects: state.projects.projects,
+    fetchingData: state.projects.fetchingData
+  }
+}
+
+export default connect(mapStateToProps, 
+  { updateData: updateProject
+  }
+)(SignUp)

--- a/src/components/SignUpComponents/SignUpBoard.js
+++ b/src/components/SignUpComponents/SignUpBoard.js
@@ -1,0 +1,17 @@
+import React from 'react'
+
+import { SignUpBoardContainer } from './SignUpStyleComponents'
+import SignUpList from './SignUpList'
+import ProjectSignUpForm from './ProjectSignUpForm'
+
+const SignUpBoard = (props) => {
+  return (
+    <SignUpBoardContainer>
+      <h2>User Sign Up Board:</h2>
+      <SignUpList {...props} />
+      <ProjectSignUpForm {...props} />
+    </SignUpBoardContainer>
+  )
+}
+
+export default SignUpBoard

--- a/src/components/SignUpComponents/SignUpBoard.js
+++ b/src/components/SignUpComponents/SignUpBoard.js
@@ -8,8 +8,8 @@ const SignUpBoard = (props) => {
   return (
     <SignUpBoardContainer>
       <h2>User Sign Up Board:</h2>
-      <SignUpList {...props} />
       <ProjectSignUpForm {...props} />
+      <SignUpList {...props} />
     </SignUpBoardContainer>
   )
 }

--- a/src/components/SignUpComponents/SignUpList.js
+++ b/src/components/SignUpComponents/SignUpList.js
@@ -1,0 +1,35 @@
+import React, { Component } from 'react'
+import { connect } from 'react-redux'
+
+import SignUp from './SignUp'
+import { SignUpListContainer } from './SignUpStyleComponents'
+
+class SignUpList extends Component {
+
+  render() {
+    const { signUpList } = this.props.project
+    return (
+      <SignUpListContainer>
+        {signUpList.length > 0 && (signUpList.map((slot, index) => (
+          <SignUp 
+            key={index}
+            {...this.props} 
+            slot={slot} 
+            index={index}
+          />
+        )))}
+      </SignUpListContainer>
+    )
+  }
+
+}
+
+const mapStateToProps = state => {
+  console.log(state.projects)
+  return {
+    projects: state.projects.projects,
+    fetchingData: state.projects.fetchingData
+  }
+}
+
+export default connect(mapStateToProps, {})(SignUpList)

--- a/src/components/SignUpComponents/SignUpStyleComponents.js
+++ b/src/components/SignUpComponents/SignUpStyleComponents.js
@@ -2,6 +2,10 @@ import styled from 'styled-components'
 import { color, colorScheme, fontSizing, flex, breakpoints } from '../DesignComponents/theme'
 
 export const SignUpBoardContainer = styled.div`
+  margin-top: 20px;
+  padding: 10px;
+  border: 1px solid ${colorScheme.defaultBorderColor};
+  border-radius: 5px;
 
   h2 {
       margin-top: 20px;
@@ -29,7 +33,7 @@ export const SignUpFormContainer = styled.div`
 export const FormContainer = styled.form`
   width: 90%;
   max-width: 600px;
-  font-size: ${fontSizing.s};
+  font-size: ${fontSizing.xs};
 `
 
 export const FormGroup = styled.div`
@@ -39,7 +43,7 @@ export const FormGroup = styled.div`
   input {
     width: 42%;
     padding: 5px;
-    font-size: ${fontSizing.s};
+    font-size: ${fontSizing.xs};
   }
 
   button {
@@ -70,7 +74,7 @@ export const SignUpContainer = styled.div`
     div {
       flex: 0 0 43%;
       padding: 5px 0;
-      font-size: ${fontSizing.s};
+      font-size: ${fontSizing.xs};
     }
 
     div:last-child {
@@ -80,7 +84,7 @@ export const SignUpContainer = styled.div`
 
     i {
       justify-self: 'flex-end';
-      font-size: ${fontSizing.s};
+      font-size: ${fontSizing.xs};
     }
 `
 

--- a/src/components/SignUpComponents/SignUpStyleComponents.js
+++ b/src/components/SignUpComponents/SignUpStyleComponents.js
@@ -1,0 +1,111 @@
+import styled from 'styled-components'
+import { color, colorScheme, fontSizing, flex, breakpoints } from '../DesignComponents/theme'
+
+export const SignUpBoardContainer = styled.div`
+
+  h2 {
+      margin-top: 20px;
+      margin-bottom: 10px;
+      font-weight: bold;
+      color: ${color.darkText};
+      font-size: ${fontSizing.s};
+  }
+`
+
+
+export const SignUpFormContainer = styled.div`
+  width: 100%;
+   ${flex('column')}
+  
+  form {
+    width: 80%;
+    input {
+
+    }
+  }
+
+`
+
+export const FormContainer = styled.form`
+  width: 90%;
+  max-width: 600px;
+  font-size: ${fontSizing.s};
+`
+
+export const FormGroup = styled.div`
+  width: 100%;
+  ${flex('row', 'center', 'space-between')}
+  
+  input {
+    width: 42%;
+    padding: 5px;
+    font-size: ${fontSizing.s};
+  }
+
+  button {
+    width: 10%;
+  }
+`
+
+export const SignUpListContainer = styled.div`
+    width: 90%;
+    max-width: 600px;
+    ${flex('column','flex-start')};
+
+    ul {
+      width: 100%;
+      padding: 0;
+      list-style-type: none;
+    }
+`
+
+export const SignUpContainer = styled.div`
+    width: 100%;
+    ${flex('row', 'center', 'flex-start')}
+    margin: 5px 0;
+    padding-left: 10px;
+    border: 1px solid ${colorScheme.defaultBorderColor};
+    border-radius: 5px;
+
+    div {
+      flex: 0 0 43%;
+      padding: 5px 0;
+      font-size: ${fontSizing.s};
+    }
+
+    div:last-child {
+      justify-self: 'flex-end';
+      flex: 0 0 14%;
+    }
+
+    i {
+      justify-self: 'flex-end';
+      font-size: ${fontSizing.s};
+    }
+`
+
+export const SignUpNameList = styled.div`
+    ${flex('row')};
+    width: 100%;
+    
+    @media ${breakpoints[0]} {
+      ${flex('column','center')};
+    }
+
+`
+
+export const SignUpName = styled.div`
+    width: 100%;
+`
+
+export const DeleteContainer = styled.div`
+  ${flex('column','flex-end')};
+
+  .fa-ellipsis-v, .fa-edit {
+    margin: 5px;
+  }
+
+  .fa-ellipsis-v, .fa-trash, .fa-edit {
+    cursor: pointer;
+  }  
+`

--- a/src/dummyData.js
+++ b/src/dummyData.js
@@ -28,6 +28,7 @@ export const projects = [
         }
       }
     ],
+    signUpList: [],
     category: '',
     projectComplete: false
   },
@@ -54,6 +55,7 @@ export const projects = [
         }
       }
     ],
+    signUpList: [],
     category: '',
     projectComplete: false
   },
@@ -66,6 +68,7 @@ export const projects = [
       'User can create an account, join an existing school account, and search for existing bubls to join. They can explore interests through hashtag searches. They can connect with others and share experiences.',
     stretch: '',
     roles: [],
+    signUpList: [],    
     category: '',
     projectComplete: false
   }

--- a/src/views/Projects/ProjectDetails.js
+++ b/src/views/Projects/ProjectDetails.js
@@ -7,6 +7,7 @@ import { ProjectInfoContainer, ButtonMenu } from './ProjectStyleComponents'
 import { CheckBoxGroup } from './ProjectFormStyles'
 import RoleForm from '../../components/RoleComponents/RoleForm'
 import RoleList from '../../components/RoleComponents/RoleList'
+import SignUpBoard from '../../components/SignUpComponents/SignUpBoard'
 import Button from '../../components/DesignComponents/Button'
 
 class ProjectDetails extends Component {
@@ -164,6 +165,10 @@ class ProjectDetails extends Component {
             <RoleList {...this.props}/> 
             {/* Add project Roles */}
             <RoleForm {...this.props} />
+
+            {/* User sign up */}
+            <SignUpBoard {...this.props} />
+
             {/* Mark project complete */}
            <CheckBoxGroup>
               <label htmlFor="">Complete:</label>

--- a/src/views/Projects/ProjectDetails.js
+++ b/src/views/Projects/ProjectDetails.js
@@ -162,14 +162,10 @@ class ProjectDetails extends Component {
               )}
             <div className="stat-category">Roles:</div>
             {/* List project roles */}
+            <RoleForm {...this.props} />
+            {/* Mark project complete */}
             <RoleList {...this.props}/> 
             {/* Add project Roles */}
-            <RoleForm {...this.props} />
-
-            {/* User sign up */}
-            <SignUpBoard {...this.props} />
-
-            {/* Mark project complete */}
            <CheckBoxGroup>
               <label htmlFor="">Complete:</label>
               <input
@@ -178,6 +174,8 @@ class ProjectDetails extends Component {
                 onChange={this.toggleProjectComplete}
               />
            </CheckBoxGroup>
+            {/* User sign up */}
+            <SignUpBoard {...this.props} />
           </div>
           {/* Update project details */}
           <ButtonMenu {...this.state} onClick={this.handleUpdate}>


### PR DESCRIPTION
## Summary
[Branch Preview](https://deploy-preview-10--teambuilderapp.netlify.com/)

#### Objective
These components enable a user to sign-up for a particular project. The name then goes to a list that a project manager or administrator can view as a reference when building a team for their project.

#### Notes

- All sign up data is held in the project data object in the application's state. The latest project data object diagram can be found [here](https://docs.google.com/spreadsheets/d/1w9PZrYNrKt_kToLpL4l25JCi_RnC3Mvgpv3qXUoPjXk/edit#gid=1799879156).
- An REST API and backend database is highly recommended to enable full functionality.